### PR TITLE
Adds placehonder lables to the the default image templates.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,8 @@ resource "google_compute_instance_template" "default" {
   project     = "${var.project}"
   name_prefix = "${var.name}-"
 
+  labels = "${var.template_labels}"
+
   machine_type = "${var.machine_type}"
 
   region = "${var.region}"

--- a/variables.tf
+++ b/variables.tf
@@ -275,3 +275,10 @@ variable hc_path {
   description = "Health check, the http path to check."
   default     = "/"
 }
+
+variable template_labels {
+  description = "A dictionary of labels to append to the default template."
+  default     = {
+    "templatetype" = "placeholder"
+  }
+}


### PR DESCRIPTION
This adds a templatetype label to the default template so we can avoid deleting it later.