### PR TITLE
Scaling schedule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -149,6 +149,17 @@ resource "google_compute_autoscaler" "default" {
         target = load_balancing_utilization.value["target"]
       }
     }
+    dynamic "scaling_schedules" {
+      for_each = var.scaling_schedules
+      
+      content {
+        name = scaling_schedules.value["name"]
+        min_required_replicas = scaling_schedules.value["min_required_replicas"]
+        schedule = scaling_schedules.value["schedule"]
+        duration_sec = scaling_schedules.value["duration_sec"]
+        description = scaling_schedules.value["Austoscaling schedules for MIG"]
+      }
+    }
   }
 }
 
@@ -247,6 +258,17 @@ resource "google_compute_region_autoscaler" "default" {
 
       content {
         target = load_balancing_utilization.value["target"]
+      }
+    }
+    dynamic "scaling_schedules" {
+      for_each = var.scaling_schedules
+      
+      content {
+        name = scaling_schedules.value["name"]
+        min_required_replicas = scaling_schedules.value["min_required_replicas"]
+        schedule = scaling_schedules.value["schedule"]
+        duration_sec = scaling_schedules.value["duration_sec"]
+        description = scaling_schedules.value["Austoscaling schedules for MIG"]
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -158,7 +158,7 @@ resource "google_compute_autoscaler" "default" {
         min_required_replicas = scaling_schedules.value["min_required_replicas"]
         schedule = scaling_schedules.value["schedule"]
         duration_sec = scaling_schedules.value["duration_sec"]
-        description = scaling_schedules.value["description"]
+        # description = scaling_schedules.value["description"]
       }
     }
   }
@@ -270,7 +270,7 @@ resource "google_compute_region_autoscaler" "default" {
         min_required_replicas = scaling_schedules.value["min_required_replicas"]
         schedule = scaling_schedules.value["schedule"]
         duration_sec = scaling_schedules.value["duration_sec"]
-        description = scaling_schedules.value["description"]
+        # description = scaling_schedules.value["description"]
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,18 @@ resource "google_compute_autoscaler" "default" {
         # description = scaling_schedules.value["description"]
       }
     }
-  }
+    dynamic "scaling_schedules_west" {
+      for_each = var.scaling_schedules_west
+      
+      content {
+        name = scaling_schedules_west.value["name"]
+        min_required_replicas = scaling_schescaling_schedules_westdules.value["min_required_replicas"]
+        schedule = scaling_schedules_west.value["schedule"]
+        duration_sec = scaling_schedules_west.value["duration_sec"]
+        # description = scaling_schedules_west.value["description"]
+      }
+    }
+  }  
 }
 
 resource "google_compute_region_instance_group_manager" "default" {

--- a/main.tf
+++ b/main.tf
@@ -158,18 +158,6 @@ resource "google_compute_autoscaler" "default" {
         min_required_replicas = scaling_schedules.value["min_required_replicas"]
         schedule = scaling_schedules.value["schedule"]
         duration_sec = scaling_schedules.value["duration_sec"]
-        # description = scaling_schedules.value["description"]
-      }
-    }
-    dynamic "scaling_schedules_west" {
-      for_each = var.scaling_schedules_west
-      
-      content {
-        name = scaling_schedules_west.value["name"]
-        min_required_replicas = scaling_schedules_west.value["min_required_replicas"]
-        schedule = scaling_schedules_west.value["schedule"]
-        duration_sec = scaling_schedules_west.value["duration_sec"]
-        # description = scaling_schedules_west.value["description"]
       }
     }
   }  
@@ -273,6 +261,7 @@ resource "google_compute_region_autoscaler" "default" {
         target = load_balancing_utilization.value["target"]
       }
     }
+    
     dynamic "scaling_schedules" {
       for_each = var.scaling_schedules
       
@@ -281,18 +270,6 @@ resource "google_compute_region_autoscaler" "default" {
         min_required_replicas = scaling_schedules.value["min_required_replicas"]
         schedule = scaling_schedules.value["schedule"]
         duration_sec = scaling_schedules.value["duration_sec"]
-        # description = scaling_schedules.value["description"]
-      }
-    }
-    dynamic "scaling_schedules_west" {
-      for_each = var.scaling_schedules_west
-      
-      content {
-        name = scaling_schedules_west.value["name"]
-        min_required_replicas = scaling_schedules_west.value["min_required_replicas"]
-        schedule = scaling_schedules_west.value["schedule"]
-        duration_sec = scaling_schedules_west.value["duration_sec"]
-        # description = scaling_schedules_west.value["description"]
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -118,6 +118,7 @@ resource "google_compute_autoscaler" "default" {
   name    = var.name
   zone    = var.zone
   project = var.project
+  provider = google-beta
   target  = google_compute_instance_group_manager.default[count.index].self_link
 
   autoscaling_policy {
@@ -228,6 +229,7 @@ resource "google_compute_region_autoscaler" "default" {
   name    = var.name
   region  = var.region
   project = var.project
+  provider = google-beta
   target  = google_compute_region_instance_group_manager.default[count.index].self_link
 
   autoscaling_policy {

--- a/main.tf
+++ b/main.tf
@@ -273,6 +273,17 @@ resource "google_compute_region_autoscaler" "default" {
         # description = scaling_schedules.value["description"]
       }
     }
+    dynamic "scaling_schedules_west" {
+      for_each = var.scaling_schedules_west
+      
+      content {
+        name = scaling_schedules_west.value["name"]
+        min_required_replicas = scaling_schescaling_schedules_westdules.value["min_required_replicas"]
+        schedule = scaling_schedules_west.value["schedule"]
+        duration_sec = scaling_schedules_west.value["duration_sec"]
+        # description = scaling_schedules_west.value["description"]
+      }
+    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -166,7 +166,7 @@ resource "google_compute_autoscaler" "default" {
       
       content {
         name = scaling_schedules_west.value["name"]
-        min_required_replicas = scaling_schescaling_schedules_westdules.value["min_required_replicas"]
+        min_required_replicas = scaling_schedules_west.value["min_required_replicas"]
         schedule = scaling_schedules_west.value["schedule"]
         duration_sec = scaling_schedules_west.value["duration_sec"]
         # description = scaling_schedules_west.value["description"]
@@ -289,7 +289,7 @@ resource "google_compute_region_autoscaler" "default" {
       
       content {
         name = scaling_schedules_west.value["name"]
-        min_required_replicas = scaling_schescaling_schedules_westdules.value["min_required_replicas"]
+        min_required_replicas = scaling_schedules_west.value["min_required_replicas"]
         schedule = scaling_schedules_west.value["schedule"]
         duration_sec = scaling_schedules_west.value["duration_sec"]
         # description = scaling_schedules_west.value["description"]

--- a/main.tf
+++ b/main.tf
@@ -155,6 +155,7 @@ resource "google_compute_autoscaler" "default" {
       
       content {
         name = scaling_schedules.value["name"]
+        disabled = scaling_schedules.value["disabled"]
         min_required_replicas = scaling_schedules.value["min_required_replicas"]
         schedule = scaling_schedules.value["schedule"]
         duration_sec = scaling_schedules.value["duration_sec"]
@@ -267,6 +268,7 @@ resource "google_compute_region_autoscaler" "default" {
       
       content {
         name = scaling_schedules.value["name"]
+        disabled = scaling_schedules.value["disabled"]
         min_required_replicas = scaling_schedules.value["min_required_replicas"]
         schedule = scaling_schedules.value["schedule"]
         duration_sec = scaling_schedules.value["duration_sec"]

--- a/main.tf
+++ b/main.tf
@@ -158,7 +158,7 @@ resource "google_compute_autoscaler" "default" {
         min_required_replicas = scaling_schedules.value["min_required_replicas"]
         schedule = scaling_schedules.value["schedule"]
         duration_sec = scaling_schedules.value["duration_sec"]
-        description = scaling_schedules.value["Austoscaling schedules for MIG"]
+        description = scaling_schedules.value["description"]
       }
     }
   }
@@ -270,7 +270,7 @@ resource "google_compute_region_autoscaler" "default" {
         min_required_replicas = scaling_schedules.value["min_required_replicas"]
         schedule = scaling_schedules.value["schedule"]
         duration_sec = scaling_schedules.value["duration_sec"]
-        description = scaling_schedules.value["Austoscaling schedules for MIG"]
+        description = scaling_schedules.value["description"]
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -151,15 +151,15 @@ resource "google_compute_autoscaler" "default" {
       }
     }
     dynamic "scaling_schedules" {
-      for_each = var.scaling_schedules
-      
-      content {
-        name = scaling_schedules.value["name"]
-        disabled = scaling_schedules.value["disabled"]
-        min_required_replicas = scaling_schedules.value["min_required_replicas"]
-        schedule = scaling_schedules.value["schedule"]
-        duration_sec = scaling_schedules.value["duration_sec"]
-      }
+     for_each = var.scaling_schedules
+     
+     content {
+       name = lookup(scaling_schedules.value, "name", null)
+       disabled = lookup(scaling_schedules.value, "disabled", null)
+       min_required_replicas = lookup(scaling_schedules.value, "min_required_replicas", null)
+       schedule = lookup(scaling_schedules.value, "schedule", null)
+       duration_sec = lookup(scaling_schedules.value, "duration_sec", null)
+     }
     }
   }  
 }
@@ -264,15 +264,15 @@ resource "google_compute_region_autoscaler" "default" {
     }
     
     dynamic "scaling_schedules" {
-      for_each = var.scaling_schedules
-      
-      content {
-        name = scaling_schedules.value["name"]
-        disabled = scaling_schedules.value["disabled"]
-        min_required_replicas = scaling_schedules.value["min_required_replicas"]
-        schedule = scaling_schedules.value["schedule"]
-        duration_sec = scaling_schedules.value["duration_sec"]
-      }
+     for_each = var.scaling_schedules
+     
+     content {
+       name = lookup(scaling_schedules.value, "name", null)
+       disabled = lookup(scaling_schedules.value, "disabled", null)
+       min_required_replicas = lookup(scaling_schedules.value, "min_required_replicas", null)
+       schedule = lookup(scaling_schedules.value, "schedule", null)
+       duration_sec = lookup(scaling_schedules.value, "duration_sec", null)
+     }
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -228,9 +228,9 @@ variable scaling_schedules {
   default = [{}]
 }
 
-variable scaling_schedules_west {
-  default = [{}]
-}
+# variable scaling_schedules_west {
+#   default = [{}]
+# }
 
 variable health_check_type {
   description = "Describes the type of health check required. Valid values are empty, HTTP or HTTPS"

--- a/variables.tf
+++ b/variables.tf
@@ -228,6 +228,10 @@ variable scaling_schedules {
   default = [{}]
 }
 
+variable scaling_schedules_west {
+  default = [{}]
+}
+
 variable health_check_type {
   description = "Describes the type of health check required. Valid values are empty, HTTP or HTTPS"
   default     = "HTTP"

--- a/variables.tf
+++ b/variables.tf
@@ -228,10 +228,6 @@ variable scaling_schedules {
   default = [{}]
 }
 
-# variable scaling_schedules_west {
-#   default = [{}]
-# }
-
 variable health_check_type {
   description = "Describes the type of health check required. Valid values are empty, HTTP or HTTPS"
   default     = "HTTP"

--- a/variables.tf
+++ b/variables.tf
@@ -224,6 +224,10 @@ variable autoscaling_lb {
   default     = []
 }
 
+variable scaling_schedules {
+  default = [{}]
+}
+
 variable health_check_type {
   description = "Describes the type of health check required. Valid values are empty, HTTP or HTTPS"
   default     = "HTTP"

--- a/variables.tf
+++ b/variables.tf
@@ -227,9 +227,6 @@ variable autoscaling_lb {
 variable "scaling_schedules" {
   default = {}
 }
-variable "scaling_schedules_west" {
-  default = {}
-}
 
 variable health_check_type {
   description = "Describes the type of health check required. Valid values are empty, HTTP or HTTPS"

--- a/variables.tf
+++ b/variables.tf
@@ -224,8 +224,11 @@ variable autoscaling_lb {
   default     = []
 }
 
-variable scaling_schedules {
-  default = [{}]
+variable "scaling_schedules" {
+  default = {}
+}
+variable "scaling_schedules_west" {
+  default = {}
 }
 
 variable health_check_type {


### PR DESCRIPTION
WHY:

To add scaling schedules to MIG's.

WHAT:

It allows scaling based on the cron expression configured to manage the workload resources for peak load.