### PR TITLE
Health host header

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -297,6 +297,7 @@ resource "google_compute_health_check" "mig-https-health-check" {
   timeout_sec         = var.hc_timeout
   healthy_threshold   = var.hc_healthy_threshold
   unhealthy_threshold = var.hc_unhealthy_threshold
+  host                = var.hc_host_header
 
   https_health_check {
     port         = var.hc_port == "" ? var.service_port : var.hc_port
@@ -314,6 +315,7 @@ resource "google_compute_health_check" "mig-http-health-check" {
   timeout_sec         = var.hc_timeout
   healthy_threshold   = var.hc_healthy_threshold
   unhealthy_threshold = var.hc_unhealthy_threshold
+  host                = var.hc_host_header
 
   http_health_check {
     port         = var.hc_port == "" ? var.service_port : var.hc_port

--- a/main.tf
+++ b/main.tf
@@ -297,11 +297,11 @@ resource "google_compute_health_check" "mig-https-health-check" {
   timeout_sec         = var.hc_timeout
   healthy_threshold   = var.hc_healthy_threshold
   unhealthy_threshold = var.hc_unhealthy_threshold
-  host                = var.hc_host_header
 
   https_health_check {
     port         = var.hc_port == "" ? var.service_port : var.hc_port
     request_path = var.hc_path
+    host         = var.hc_host_header
   }
 }
 
@@ -315,11 +315,11 @@ resource "google_compute_health_check" "mig-http-health-check" {
   timeout_sec         = var.hc_timeout
   healthy_threshold   = var.hc_healthy_threshold
   unhealthy_threshold = var.hc_unhealthy_threshold
-  host                = var.hc_host_header
 
   http_health_check {
     port         = var.hc_port == "" ? var.service_port : var.hc_port
     request_path = var.hc_path
+    host         = var.hc_host_header
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -270,6 +270,11 @@ variable hc_path {
   default     = "/"
 }
 
+variable hc_host_header {
+  description = "Health check, host header to pass."
+  default     = ""
+}
+
 variable template_labels {
   description = "A dictionary of labels to append to the default template."
 


### PR DESCRIPTION
WHAT

add health check host header option

WHY

new proxies will require front end to send host headers

TEST

following branch shows no changes.  I have manually added the host header to both the GLB and MIG
https://gitlab.urbn.com/infrastructure/ecomm-terraform/merge_requests/new/diffs?merge_request%5Bsource_branch%5D=an_health_header