### PR TITLE
Switching map to tomap for TF v1.4.7

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ resource "google_compute_instance_template" "default" {
   }
 
   metadata = merge(
-    tomap("startup-script", var.startup_script, "tf_depends_id", var.depends_id),
+    tomap({"startup-script" = var.startup_script, "tf_depends_id" = var.depends_id}),
     var.metadata
   )
 

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ resource "google_compute_instance_template" "default" {
   }
 
   metadata = merge(
-    map("startup-script", var.startup_script, "tf_depends_id", var.depends_id),
+    tomap("startup-script", var.startup_script, "tf_depends_id", var.depends_id),
     var.metadata
   )
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,7 +21,7 @@ output name {
 
 output instance_group {
   description = "Link to the `instance_group` property of the instance group manager resource."
-  value       = "${element(concat(google_compute_instance_group_manager.default.*.instance_group, list("")), 0)}"
+  value       = "${element(concat(google_compute_instance_group_manager.default.*.instance_group, tolist([""])), 0)}"
 }
 
 output instances {
@@ -31,7 +31,7 @@ output instances {
 
 output region_instance_group {
   description = "Link to the `instance_group` property of the region instance group manager resource."
-  value       = "${element(concat(google_compute_region_instance_group_manager.default.*.instance_group, list("")), 0)}"
+  value       = "${element(concat(google_compute_region_instance_group_manager.default.*.instance_group, tolist([""])), 0)}"
 }
 
 output target_tags {
@@ -51,12 +51,12 @@ output service_port_name {
 
 output depends_id {
   description = "Id of the dummy dependency created used for intra-module dependency creation with zonal groups."
-  value       = "${element(concat(null_resource.dummy_dependency.*.id, list("")), 0)}"
+  value       = "${element(concat(null_resource.dummy_dependency.*.id, tolist([""])), 0)}"
 }
 
 output region_depends_id {
   description = "Id of the dummy dependency created used for intra-module dependency creation with regional groups."
-  value       = "${element(concat(null_resource.region_dummy_dependency.*.id, list("")), 0)}"
+  value       = "${element(concat(null_resource.region_dummy_dependency.*.id, tolist([""])), 0)}"
 }
 
 output network_ip {


### PR DESCRIPTION
**WHAT**  
Updating map to use `tomap`. 

**WHY**  
Upgrading staging API to TF version 1.4.7 causes this output in the plan:
```
Error: Error in function call
│
│   on .terraform/modules/us_west1_urbncat_celery_mig/main.tf line 63, in resource "google_compute_instance_template" "default":
│   63:     map("startup-script", var.startup_script, "tf_depends_id", var.depends_id),
│     ├────────────────
│     │ while calling map(vals...)
│
│ Call to function "map" failed: the "map" function was deprecated in Terraform v0.12 and is no longer available; use tomap({ ... }) syntax to write a literal map.
```